### PR TITLE
Correct tests under extreme timezones

### DIFF
--- a/mopidy_podcast/feeds.py
+++ b/mopidy_podcast/feeds.py
@@ -140,7 +140,9 @@ class RssFeed(PodcastFeed):
         except TypeError:
             return None
         else:
-            return datetime.date.fromtimestamp(timestamp).isoformat()
+            return datetime.datetime.utcfromtimestamp(
+                timestamp,
+            ).date().isoformat()
 
     @classmethod
     def __genre(cls, etree):


### PR DESCRIPTION
For example with ``TZ=/usr/share/zoneinfo/Etc/GMT-14``, the tests fail with:

```
=================================== FAILURES ===================================
_________________________________ test_tracks __________________________________

rss = <mopidy_podcast.feeds.RssFeed object at 0x7ff6b62fc310>
tracks = [Track(album=Album(artists=[Artist(name=u'John Doe')], name=u'All About Everyth...ces', track_no=3, uri='podcast+http:...ohn Doe')], name=u'All About Everyth...p://www.example.com/everything.xml#http://example.com/everything/Episode1.mp3')]

    def test_tracks(rss, tracks):
>       assert list(rss.tracks(newest_first=True)) == tracks
E       assert [Track(album=...pisode1.mp3')] == [Track(album=A...pisode1.mp3')]
E         At index 0 diff: Track(album=Album(artists=[Artist(name=u'John Doe')], name=u'All About Everything', num_tracks=3, uri='podcast+http://www.example.com/everything.xml'), artists=[Artist(name=u'John Doe')], date='2014-06-16', genre='Technology', length=424000, name='Shake Shake Shake Your Spices', track_no=3, uri='podcast+http://www.example.com/everything.xml#episode3') != Track(album=Album(artists=[Artist(name=u'John Doe')], name=u'All About Everything', num_tracks=3, uri='podcast+http://www.example.com/everything.xml'), artists=[Artist(name=u'John Doe')], date=u'2014-06-15', genre=u'Technology', length=424000, name=u'Shake Shake Shake Your Spices', track_no=3, uri='podcast+http://www.example.com/everything.xml#episode3')
E         Use -v to get the full diff
E         Detailed information truncated (-7 more lines), use "-vv" to show
```

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>