### PR TITLE
Fix case-sensitive OPML feed parser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@ def get_version(filename):
         metadata = dict(findall(r"__([a-z]+)__ = '([^']+)'", f.read()))
     return metadata['version']
 
+
 project = 'Mopidy-Podcast'
 copyright = '2014-2016 Thomas Kemmer'
 version = get_version(b'../mopidy_podcast/__init__.py')

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -6,6 +6,11 @@ import uritools
 
 from mopidy_podcast import feeds
 
+try:
+    import xml.etree.cElementTree as ElementTree
+except ImportError:
+    import xml.etree.ElementTree as ElementTree
+
 
 @pytest.mark.parametrize('filename,expected', [
     ('directory.xml', feeds.OpmlFeed),
@@ -17,3 +22,19 @@ def test_parse(abspath, filename, expected):
     feed = feeds.parse(path)
     assert isinstance(feed, expected)
     assert feed.uri == uritools.uricompose('podcast+file', '', path)
+
+
+def test_case_sensitive_parse():
+    xml = r'''<?xml version="1.0" encoding="utf-8" ?>
+    <opml version="1.1">
+        <head title="Podcasts">
+            <expansionState></expansionState>
+        </head>
+        <body>
+            <outline URL="http://example.com/" text="example" type="link" />
+        </body>
+    </opml>
+    '''
+    root = ElementTree.fromstring(xml)
+    feed = feeds.OpmlFeed('foo', root)
+    assert feed.items().next().uri == 'podcast+http://example.com/'


### PR DESCRIPTION
The OPML spec seems to be ambiguous on the subject of case-sensitivity.
As a result, OPML feeds that are exported from podcatchers may have
uppercase attributes (i.e., `URL` vs `url`). This patch will find
attributes of `xml.etree.ElementTree.Element` objects in a
case-insensitive way which side-steps the problem.

I ran into this importing my podcast opml from [mysqueezebox.com](http://mysqueezebox.com/public/opml/9d2db4de507c61d63d8eec3efb3f0d6bb1d2bb51/podcasts.opml). Adding this OPML as the `browse_root` caused a stack-trace in my mopidy log:

```
Jan 06 12:31:03 radio mopidy[458]: ERROR    PodcastBackend backend caused an exception.                                          
Jan 06 12:31:03 radio mopidy[458]: Traceback (most recent call last):                                       
Jan 06 12:31:03 radio mopidy[458]:   File "/usr/lib/python2.7/dist-packages/mopidy/core/library.py", line 19, in _backend_error_handling                                  
Jan 06 12:31:03 radio mopidy[458]:     yield                                                                            
Jan 06 12:31:03 radio mopidy[458]:   File "/usr/lib/python2.7/dist-packages/mopidy/core/library.py", line 112, in _browse
Jan 06 12:31:03 radio mopidy[458]:     result = backend.library.browse(uri).get()                                                       
Jan 06 12:31:03 radio mopidy[458]:   File "/usr/lib/python2.7/dist-packages/pykka/threading.py", line 52, in get                                                         
Jan 06 12:31:03 radio mopidy[458]:     compat.reraise(*self._data['exc_info'])                                           
Jan 06 12:31:03 radio mopidy[458]:   File "/usr/lib/python2.7/dist-packages/pykka/compat.py", line 12, in reraise        
Jan 06 12:31:03 radio mopidy[458]:     exec('raise tp, value, tb')                                              
Jan 06 12:31:03 radio mopidy[458]:   File "/usr/lib/python2.7/dist-packages/pykka/actor.py", line 201, in _actor_loop                       
Jan 06 12:31:03 radio mopidy[458]:     response = self._handle_receive(message)                                  
Jan 06 12:31:03 radio mopidy[458]:   File "/usr/lib/python2.7/dist-packages/pykka/actor.py", line 295, in _handle_receive
Jan 06 12:31:03 radio mopidy[458]:     return callee(*message['args'], **message['kwargs'])                          
Jan 06 12:31:03 radio mopidy[458]:   File "/usr/local/lib/python2.7/dist-packages/mopidy_podcast/library.py", line 68, in browse                                         
Jan 06 12:31:03 radio mopidy[458]:     return list(feed.items(self.__browse_order == 'desc'))                            
Jan 06 12:31:03 radio mopidy[458]:   File "/usr/local/lib/python2.7/dist-packages/mopidy_podcast/feeds.py", line 226, in items              
Jan 06 12:31:03 radio mopidy[458]:     yield ref(e)                                                                             
Jan 06 12:31:03 radio mopidy[458]:   File "/usr/local/lib/python2.7/dist-packages/mopidy_podcast/feeds.py", line 203, in <lambda>
Jan 06 12:31:03 radio mopidy[458]:     if e.get('url').endswith('.opml')
Jan 06 12:31:03 radio mopidy[458]: AttributeError: 'NoneType' object has no attribute 'endswith'
Jan 06 12:31:05 radio mopidy[458]: ERROR    PodcastBackend backend caused an exception.
```

The reason, of course, is that the `url` attribute in my OPML feed is actually the `URL` attribute.