### PR TITLE
Parse uppercase URL feed elements

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@ def get_version(filename):
         metadata = dict(findall(r"__([a-z]+)__ = '([^']+)'", f.read()))
     return metadata['version']
 
+
 project = 'Mopidy-Podcast'
 copyright = '2014-2016 Thomas Kemmer'
 version = get_version(b'../mopidy_podcast/__init__.py')

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -6,6 +6,11 @@ import uritools
 
 from mopidy_podcast import feeds
 
+try:
+    import xml.etree.cElementTree as ElementTree
+except ImportError:
+    import xml.etree.ElementTree as ElementTree
+
 
 @pytest.mark.parametrize('filename,expected', [
     ('directory.xml', feeds.OpmlFeed),
@@ -17,3 +22,19 @@ def test_parse(abspath, filename, expected):
     feed = feeds.parse(path)
     assert isinstance(feed, expected)
     assert feed.uri == uritools.uricompose('podcast+file', '', path)
+
+
+def test_parse_uppercase_url():
+    xml = r'''<?xml version="1.0" encoding="utf-8" ?>
+    <opml version="1.1">
+        <head title="Podcasts">
+            <expansionState></expansionState>
+        </head>
+        <body>
+            <outline URL="http://example.com/" text="example" type="link" />
+        </body>
+    </opml>
+    '''
+    root = ElementTree.fromstring(xml)
+    feed = feeds.OpmlFeed('foo', root)
+    assert feed.items().next().uri == 'podcast+http://example.com/'


### PR DESCRIPTION
In some instances the `url` attribute for for an xml element may be
capitalized.

See #46 for more discussion.