### PR TITLE
Switch to decorator for marking object as pykka traversable

### DIFF
--- a/mopidy_podcast/backend.py
+++ b/mopidy_podcast/backend.py
@@ -12,10 +12,8 @@ from .playback import PodcastPlaybackProvider
 logger = logging.getLogger(__name__)
 
 
+@pykka.traversable
 class PodcastFeedCache(cachetools.TTLCache):
-
-    pykka_traversable = True
-
     def __init__(self, config):
         super().__init__(
             maxsize=config[Extension.ext_name]["cache_size"],


### PR DESCRIPTION
This is the new supported way of marking classes as traversable. The old
approach of setting a class var will likely be removed at some point, so
we should switch.