### PR TITLE
Support pathlib for feed filenames in parse() function

### DIFF
--- a/mopidy_podcast/feeds.py
+++ b/mopidy_podcast/feeds.py
@@ -1,6 +1,7 @@
 import datetime
 import email.utils
 import re
+from pathlib import Path
 
 import uritools
 from mopidy import models
@@ -14,6 +15,8 @@ except ImportError:
 
 
 def parse(source):
+    if isinstance(source, Path):
+        source = str(source)
     if isinstance(source, str):
         url = uritools.uricompose("file", "", source)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import functools
 import os
+from pathlib import Path
 from unittest import mock
 
 import mopidy_podcast as ext
@@ -7,8 +8,13 @@ import pytest
 
 
 @pytest.fixture
-def abspath():
-    return functools.partial(os.path.join, os.path.dirname(__file__))
+def testpath() -> Path:
+    return Path(__file__).parent
+
+
+@pytest.fixture
+def abspath(testpath: Path):
+    return functools.partial(os.path.join, str(testpath))
 
 
 @pytest.fixture
@@ -17,7 +23,7 @@ def audio():
 
 
 @pytest.fixture
-def config():
+def config(testpath: Path):
     return {
         "podcast": {
             "browse_root": "Podcasts.opml",
@@ -27,7 +33,7 @@ def config():
             "cache_ttl": 86400,
             "timeout": 10,
         },
-        "core": {"config_dir": os.path.dirname(__file__)},
+        "core": {"config_dir": testpath},
         "proxy": {},
     }
 

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -1,4 +1,5 @@
 import uritools
+from pathlib import Path
 
 import pytest
 from mopidy_podcast import feeds
@@ -8,8 +9,8 @@ from mopidy_podcast import feeds
     "filename,expected",
     [("directory.xml", feeds.OpmlFeed), ("rssfeed.xml", feeds.RssFeed)],
 )
-def test_parse(abspath, filename, expected):
-    path = abspath(filename)
+def test_parse(testpath: Path, filename: str, expected):
+    path = testpath / filename
     feed = feeds.parse(path)
     assert isinstance(feed, expected)
-    assert feed.uri == uritools.uricompose("podcast+file", "", path)
+    assert feed.uri == uritools.uricompose("podcast+file", "", str(path))


### PR DESCRIPTION
The mopidy core is using pathlib internally, and its use is growing
everywhere all the time.